### PR TITLE
provide an after unlock hook

### DIFF
--- a/lib/sidekiq_unique_jobs/middleware/server/unique_jobs.rb
+++ b/lib/sidekiq_unique_jobs/middleware/server/unique_jobs.rb
@@ -22,6 +22,7 @@ module SidekiqUniqueJobs
         ensure
           if !shutdown && (after_yield? || !defined? unlocked || unlocked != 1)
             unlock(lock_key)
+            after_unlock_hook(worker)
           end
         end
 
@@ -58,6 +59,12 @@ module SidekiqUniqueJobs
 
         def unlock(payload_hash)
           connection { |c| c.del(payload_hash) }
+        end
+
+        def after_unlock_hook(worker)
+          if worker.respond_to?(:after_unlock)
+            worker.after_unlock
+          end
         end
 
         def logger

--- a/spec/support/after_unlock_worker.rb
+++ b/spec/support/after_unlock_worker.rb
@@ -1,0 +1,17 @@
+class AfterUnlockWorker
+  include Sidekiq::Worker
+  sidekiq_options queue: :working, retry: 1, backtrace: 10, unique_unlock_order: :after_yield
+  sidekiq_options unique: false
+
+  sidekiq_retries_exhausted do |msg|
+    Sidekiq.logger.warn "Failed #{msg['class']} with #{msg['args']}: #{msg['error_message']}"
+  end
+
+  def perform(*)
+    # NO-OP
+  end
+
+  def after_unlock(*)
+    # NO-OP
+  end
+end


### PR DESCRIPTION
@primiti @deltaroe add an after unlock hook only for after_yield workers.

I contemplated passing the args along again, but the instance is persisted, so should be safe to use an instance variable for now.
