### PR TITLE
Lock by jid

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,11 +8,12 @@ rvm:
   - 2.1.2
   - 2.2.2
 gemfile:
+  - gemfiles/sidekiq_develop.gemfile
+  - gemfiles/sidekiq_2.17.gemfile
   - gemfiles/sidekiq_3.0.gemfile
   - gemfiles/sidekiq_3.1.gemfile
   - gemfiles/sidekiq_3.2.gemfile
   - gemfiles/sidekiq_3.3.gemfile
-  - gemfiles/sidekiq_develop.gemfile
 branches:
   only:
     - master

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## v3.0.14
+- Improve uniqueness check performance thanks @mpherham
+- Remove locks in sidekiq fake testing mode
+- Do not unlock jobs when sidekiq is shutting down 
+
 ## v3.0.13
 - Improved testing capabilities (testing uniqueness should not work better)
 - Configurable logging of duplicate payloads

--- a/README.md
+++ b/README.md
@@ -109,6 +109,17 @@ class UniqueJobWithFilterMethod
 end
 ```
 
+### Unique Storage Method
+
+Starting from sidekiq-unique-jobs 3.0.14 we will use the `set` method in a way that has been available since redis 2.6.12. If you are on an older redis version you will have to change a config value like below.
+
+```ruby
+SidekiqUniqueJobs.config.unique_storage_method = :old
+```
+
+That should allow you to keep using redis in the old fashion way. See #89 for mor information.
+
+
 ### Logging
 
 To see logging in sidekiq when duplicate payload has been filtered out you can enable on a per worker basis using the sidekiq options.  The default value is false

--- a/gemfiles/sidekiq_2.17.gemfile
+++ b/gemfiles/sidekiq_2.17.gemfile
@@ -2,7 +2,7 @@
 
 source "http://rubygems.org"
 
-gem "appraisal", "~> 1.0.0"
+gem "appraisal", "~> 2.0.0"
 gem "pry", :platform => :mri
 gem "sidekiq", "~> 2.17.0"
 

--- a/lib/sidekiq-unique-jobs.rb
+++ b/lib/sidekiq-unique-jobs.rb
@@ -16,7 +16,8 @@ module SidekiqUniqueJobs
       unique_prefix: 'sidekiq_unique',
       unique_args_enabled: false,
       default_expiration: 30 * 60,
-      default_unlock_order: :after_yield
+      default_unlock_order: :after_yield,
+      unique_storage_method: :old
     )
   end
 

--- a/lib/sidekiq-unique-jobs.rb
+++ b/lib/sidekiq-unique-jobs.rb
@@ -17,7 +17,7 @@ module SidekiqUniqueJobs
       unique_args_enabled: false,
       default_expiration: 30 * 60,
       default_unlock_order: :after_yield,
-      unique_storage_method: :old
+      unique_storage_method: :new
     )
   end
 

--- a/lib/sidekiq_unique_jobs/config.rb
+++ b/lib/sidekiq_unique_jobs/config.rb
@@ -4,7 +4,8 @@ module SidekiqUniqueJobs
       :unique_prefix,
       :unique_args_enabled,
       :default_expiration,
-      :default_unlock_order
+      :default_unlock_order,
+      :unique_storage_method
     ]
 
     class << self

--- a/lib/sidekiq_unique_jobs/middleware/client/strategies/unique.rb
+++ b/lib/sidekiq_unique_jobs/middleware/client/strategies/unique.rb
@@ -79,7 +79,7 @@ module SidekiqUniqueJobs
 
           def new_unique_for?
             connection do |conn|
-              return conn.set(payload_hash, item['jid'], nx: true, ex: expires_at)
+              return conn.set(payload_hash, item['jid'], nx: true, ex: expires_at) || conn.get(payload_hash) == item['jid']
             end
           end
 

--- a/lib/sidekiq_unique_jobs/middleware/client/strategies/unique.rb
+++ b/lib/sidekiq_unique_jobs/middleware/client/strategies/unique.rb
@@ -17,7 +17,9 @@ module SidekiqUniqueJobs
           end
 
           def self.review(worker_class, item, queue, redis_pool = nil, log_duplicate_payload = false)
-            new(worker_class, item, queue, redis_pool, log_duplicate_payload).review { yield }
+            new(worker_class, item, queue, redis_pool, log_duplicate_payload).review do
+              yield
+            end
           end
 
           def initialize(worker_class, item, queue, redis_pool = nil, log_duplicate_payload = false)
@@ -31,12 +33,12 @@ module SidekiqUniqueJobs
 
           def review
             item['unique_hash'] = payload_hash
-            unless unique_for_connection?
-              if @log_duplicate_payload
-                Sidekiq.logger.warn "payload is not unique #{item}"
-              end
+
+            unless stored_in_redis?
+              Sidekiq.logger.warn "payload is not unique #{item}" if @log_duplicate_payload
               return
             end
+
             yield
           end
 
@@ -44,32 +46,19 @@ module SidekiqUniqueJobs
 
           attr_reader :item, :worker_class, :redis_pool, :queue, :log_duplicate_payload
 
-          # rubocop:disable MethodLength
-          def unique_for_connection?
-            unique = false
+          def stored_in_redis?
             connection do |conn|
-              conn.watch(payload_hash)
-
-              if conn.get(payload_hash).to_i == 1 ||
-                 (conn.get(payload_hash).to_i == 2 && item['at'])
-                # if the job is already queued, or is already scheduled and
-                # we're trying to schedule again, abort
-                conn.unwatch
-              else
-                # if the job was previously scheduled and is now being queued,
-                # or we've never seen it before
-                expires_at = unique_job_expiration || SidekiqUniqueJobs.config.default_expiration
-                expires_at = ((Time.at(item['at']) - Time.now.utc) + expires_at).to_i if item['at']
-
-                unique = conn.multi do
-                  # set value of 2 for scheduled jobs, 1 for queued jobs.
-                  conn.setex(payload_hash, expires_at, item['at'] ? 2 : 1)
-                end
-              end
+              return conn.set(payload_hash, item['at'] ? 2 : 1, nx: true, ex: expires_at)
             end
-            unique
           end
-          # rubocop:enable MethodLength
+
+          def expires_at
+            # if the job was previously scheduled and is now being queued,
+            # or we've never seen it before
+            ex = unique_job_expiration || SidekiqUniqueJobs.config.default_expiration
+            ex = ((Time.at(item['at']) - Time.now.utc) + ex).to_i if item['at']
+            ex
+          end
 
           def connection(&block)
             SidekiqUniqueJobs::Connectors.connection(redis_pool, &block)

--- a/lib/sidekiq_unique_jobs/middleware/server/unique_jobs.rb
+++ b/lib/sidekiq_unique_jobs/middleware/server/unique_jobs.rb
@@ -8,20 +8,18 @@ module SidekiqUniqueJobs
         attr_reader :unlock_order, :redis_pool
 
         def call(worker, item, _queue, redis_pool = nil)
-          operative = true
           @redis_pool = redis_pool
           decide_unlock_order(worker.class)
           lock_key = payload_hash(item)
           unlock(lock_key) if before_yield?
-          yield
-        rescue Sidekiq::Shutdown
-          operative = false
-          raise
-        ensure
-          if after_yield? && operative
+
+          result = yield
+
+          if after_yield?
             unlock(lock_key)
             after_unlock_hook(worker)
           end
+          result
         end
 
         def decide_unlock_order(klass)

--- a/lib/sidekiq_unique_jobs/middleware/server/unique_jobs.rb
+++ b/lib/sidekiq_unique_jobs/middleware/server/unique_jobs.rb
@@ -12,13 +12,11 @@ module SidekiqUniqueJobs
 
           decide_unlock_order(worker.class)
           lock_key = payload_hash(item)
-          unlocked = before_yield? ? unlock(lock_key).inspect : 0
+          unlock(lock_key) if before_yield?
 
           yield
         ensure
-          if after_yield? || !defined? unlocked || unlocked != 1
-            unlock(lock_key)
-          end
+          unlock(lock_key) if after_yield?
         end
 
         def decide_unlock_order(klass)

--- a/lib/sidekiq_unique_jobs/version.rb
+++ b/lib/sidekiq_unique_jobs/version.rb
@@ -1,3 +1,3 @@
 module SidekiqUniqueJobs
-  VERSION = '3.0.13'
+  VERSION = '3.0.14'
 end

--- a/spec/lib/client_spec.rb
+++ b/spec/lib/client_spec.rb
@@ -57,13 +57,21 @@ describe 'Client' do
 
     it 'enqueues previously scheduled job' do
       QueueWorker.sidekiq_options unique: true
-      QueueWorker.perform_in(60 * 60, [1, 2])
+      jid = QueueWorker.perform_in(60 * 60, [1, 2])
 
       # time passes and the job is pulled off the schedule:
-      Sidekiq::Client.push('class' => QueueWorker, 'queue' => 'customqueue', 'args' => [1, 2])
+      Sidekiq::Client.push('class' => QueueWorker, 'queue' => 'customqueue', 'args' => [1, 2], 'jid' => jid)
 
       result = Sidekiq.redis { |c| c.llen('queue:customqueue') }
       expect(result).to eq 1
+    end
+
+    it 'prevents a unique task that is scheduled in the future from being run now' do
+      QueueWorker.sidekiq_options unique: true
+      QueueWorker.perform_in(60 * 60, 1, 2)
+
+      result = QueueWorker.perform_async(1, 2)
+      expect(result).to be_nil
     end
 
     it 'sets an expiration when provided by sidekiq options' do

--- a/spec/lib/client_spec.rb
+++ b/spec/lib/client_spec.rb
@@ -57,7 +57,7 @@ describe 'Client' do
 
     it 'enqueues previously scheduled job' do
       QueueWorker.sidekiq_options unique: true
-      jid = QueueWorker.perform_in(60 * 60, [1, 2])
+      jid = QueueWorker.perform_in(60 * 60, 1, 2)
 
       # time passes and the job is pulled off the schedule:
       Sidekiq::Client.push('class' => QueueWorker, 'queue' => 'customqueue', 'args' => [1, 2], 'jid' => jid)

--- a/spec/lib/client_spec.rb
+++ b/spec/lib/client_spec.rb
@@ -57,7 +57,7 @@ describe 'Client' do
 
     it 'enqueues previously scheduled job' do
       QueueWorker.sidekiq_options unique: true
-      QueueWorker.perform_in(60 * 60, 1, 2)
+      QueueWorker.perform_in(60 * 60, [1, 2])
 
       # time passes and the job is pulled off the schedule:
       Sidekiq::Client.push('class' => QueueWorker, 'queue' => 'customqueue', 'args' => [1, 2])

--- a/spec/lib/middleware/server/unique_jobs_spec.rb
+++ b/spec/lib/middleware/server/unique_jobs_spec.rb
@@ -93,16 +93,10 @@ module SidekiqUniqueJobs
               uj.call(*items) { true }
             end
 
-            it 'should unlock after yield when call errors' do
-              expect(uj).to receive(:unlock)
-
-              expect { uj.call(*items) { fail } }.to raise_error(RuntimeError)
-            end
-
-            it 'should not unlock after yield on shutdown, but still raise error' do
+            it 'should not unlock after yield when call errors' do
               expect(uj).to_not receive(:unlock)
 
-              expect { uj.call(*items) { fail Sidekiq::Shutdown } }.to raise_error(Sidekiq::Shutdown)
+              expect { uj.call(*items) { fail } }.to raise_error(RuntimeError)
             end
           end
 

--- a/spec/lib/middleware/server/unique_jobs_spec.rb
+++ b/spec/lib/middleware/server/unique_jobs_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'sidekiq/cli'
 
 module SidekiqUniqueJobs
   module Middleware
@@ -8,14 +9,14 @@ module SidekiqUniqueJobs
           context "when class isn't a Sidekiq::Worker" do
             it 'returns false' do
               expect(subject.unlock_order_configured?(Class))
-                .to eq(false)
+                  .to eq(false)
             end
           end
 
           context 'when get_sidekiq_options[:unique_unlock_order] is nil' do
             it 'returns false' do
               expect(subject.unlock_order_configured?(MyWorker))
-                .to eq(false)
+                  .to eq(false)
             end
           end
 
@@ -78,6 +79,29 @@ module SidekiqUniqueJobs
 
             SidekiqUniqueJobs.config.default_unlock_order = :after_yield
             expect(subject.default_unlock_order).to eq(:after_yield)
+          end
+        end
+
+        describe '#call' do
+          context 'unlock' do
+            let(:uj) { SidekiqUniqueJobs::Middleware::Server::UniqueJobs.new }
+            it 'should unlock after yield when call succeeds' do
+              expect(uj).to receive(:unlock)
+
+              uj.call(UniqueWorker.new, { 'class' => 'testClass' }, 'test') { true }
+            end
+
+            it 'should unlock after yield when call errors' do
+              expect(uj).to receive(:unlock)
+
+              expect{ uj.call(UniqueWorker.new, { 'class' => 'testClass' }, 'test') { raise } }.to raise_error(RuntimeError)
+            end
+
+            it 'should not unlock after yield on shutdown, but still raise error' do
+              expect(uj).to_not receive(:unlock)
+
+              expect{ uj.call(UniqueWorker.new, { 'class' => 'testClass' }, 'test') { raise Sidekiq::Shutdown } }.to raise_error(Sidekiq::Shutdown)
+            end
           end
         end
       end

--- a/spec/lib/middleware/server/unique_jobs_spec.rb
+++ b/spec/lib/middleware/server/unique_jobs_spec.rb
@@ -85,22 +85,24 @@ module SidekiqUniqueJobs
         describe '#call' do
           context 'unlock' do
             let(:uj) { SidekiqUniqueJobs::Middleware::Server::UniqueJobs.new }
+            let(:items) { [UniqueWorker.new, { 'class' => 'testClass' }, 'test'] }
+
             it 'should unlock after yield when call succeeds' do
               expect(uj).to receive(:unlock)
 
-              uj.call(UniqueWorker.new, { 'class' => 'testClass' }, 'test') { true }
+              uj.call(*items) { true }
             end
 
             it 'should unlock after yield when call errors' do
               expect(uj).to receive(:unlock)
 
-              expect{ uj.call(UniqueWorker.new, { 'class' => 'testClass' }, 'test') { raise } }.to raise_error(RuntimeError)
+              expect { uj.call(*items) { fail } }.to raise_error(RuntimeError)
             end
 
             it 'should not unlock after yield on shutdown, but still raise error' do
               expect(uj).to_not receive(:unlock)
 
-              expect{ uj.call(UniqueWorker.new, { 'class' => 'testClass' }, 'test') { raise Sidekiq::Shutdown } }.to raise_error(Sidekiq::Shutdown)
+              expect { uj.call(*items) { fail Sidekiq::Shutdown } }.to raise_error(Sidekiq::Shutdown)
             end
           end
         end

--- a/spec/lib/middleware/server/unique_jobs_spec.rb
+++ b/spec/lib/middleware/server/unique_jobs_spec.rb
@@ -20,8 +20,10 @@ module SidekiqUniqueJobs
           end
 
           it 'returns true when unique_unlock_order has been set' do
-            UniqueWorker.sidekiq_options unique_unlock_order: :before_yield
-            expect(subject.unlock_order_configured?(UniqueWorker))
+            test_worker_class = UniqueWorker.dup
+            test_worker_class.sidekiq_options unique_unlock_order: :before_yield
+
+            expect(subject.unlock_order_configured?(test_worker_class))
               .to eq(true)
           end
         end
@@ -29,9 +31,11 @@ module SidekiqUniqueJobs
         describe '#decide_unlock_order' do
           context 'when worker has specified unique_unlock_order' do
             it 'changes unlock_order to the configured value' do
-              UniqueWorker.sidekiq_options unique_unlock_order: :before_yield
+              test_worker_class = UniqueWorker.dup
+              test_worker_class.sidekiq_options unique_unlock_order: :before_yield
+
               expect do
-                subject.decide_unlock_order(UniqueWorker)
+                subject.decide_unlock_order(test_worker_class)
               end.to change { subject.unlock_order }.to :before_yield
             end
           end
@@ -39,6 +43,7 @@ module SidekiqUniqueJobs
           context "when worker hasn't specified unique_unlock_order" do
             it 'falls back to configured default_unlock_order' do
               SidekiqUniqueJobs.config.default_unlock_order = :before_yield
+
               expect do
                 subject.decide_unlock_order(UniqueWorker)
               end.to change { subject.unlock_order }.to :before_yield

--- a/spec/lib/middleware/server/unique_jobs_spec.rb
+++ b/spec/lib/middleware/server/unique_jobs_spec.rb
@@ -9,14 +9,14 @@ module SidekiqUniqueJobs
           context "when class isn't a Sidekiq::Worker" do
             it 'returns false' do
               expect(subject.unlock_order_configured?(Class))
-                  .to eq(false)
+                .to eq(false)
             end
           end
 
           context 'when get_sidekiq_options[:unique_unlock_order] is nil' do
             it 'returns false' do
               expect(subject.unlock_order_configured?(MyWorker))
-                  .to eq(false)
+                .to eq(false)
             end
           end
 

--- a/spec/lib/middleware/server/unique_jobs_spec.rb
+++ b/spec/lib/middleware/server/unique_jobs_spec.rb
@@ -85,7 +85,7 @@ module SidekiqUniqueJobs
         describe '#call' do
           context 'unlock' do
             let(:uj) { SidekiqUniqueJobs::Middleware::Server::UniqueJobs.new }
-            let(:items) { [UniqueWorker.new, { 'class' => 'testClass' }, 'test'] }
+            let(:items) { [AfterYieldWorker.new, { 'class' => 'testClass' }, 'test'] }
 
             it 'should unlock after yield when call succeeds' do
               expect(uj).to receive(:unlock)

--- a/spec/lib/unlock_order_spec.rb
+++ b/spec/lib/unlock_order_spec.rb
@@ -48,7 +48,9 @@ describe 'Unlock order' do
 
     describe ':after_yield' do
       it 'removes the lock after yielding to the worker' do
+
         jid = AfterYieldOrderingWorker.perform_async
+
         item = Sidekiq::Queue.new(QUEUE).find_job(jid).item
 
         result = @middleware.call(AfterYieldOrderingWorker.new, item, QUEUE) do
@@ -57,7 +59,7 @@ describe 'Unlock order' do
           end
         end
 
-        expect(result).to eq '1'
+        expect(result).to eq jid
       end
     end
   end

--- a/spec/support/after_yield_worker.rb
+++ b/spec/support/after_yield_worker.rb
@@ -1,6 +1,6 @@
 class AfterYieldWorker
   include Sidekiq::Worker
-  sidekiq_options queue: :working, retry: 1, backtrace: 10, after_yield: true
+  sidekiq_options queue: :working, retry: 1, backtrace: 10, unique_unlock_order: :after_yield
   sidekiq_options unique: false
 
   sidekiq_retries_exhausted do |msg|

--- a/spec/support/after_yield_worker.rb
+++ b/spec/support/after_yield_worker.rb
@@ -1,0 +1,13 @@
+class AfterYieldWorker
+  include Sidekiq::Worker
+  sidekiq_options queue: :working, retry: 1, backtrace: 10, after_yield: true
+  sidekiq_options unique: false
+
+  sidekiq_retries_exhausted do |msg|
+    Sidekiq.logger.warn "Failed #{msg['class']} with #{msg['args']}: #{msg['error_message']}"
+  end
+
+  def perform(*)
+    # NO-OP
+  end
+end


### PR DESCRIPTION
@HParker @primiti 

This changes unique job to use the jid instead of a 1:2 as the value stored in the lock key.  This has the advantage that it allows a job to move from the scheduled and retry queues to the normal queue, but prevents a new job from being scheduled "now" if it's also scheduled in the future. 

This will fix the strange interactions between the sidekiq retry system and unique jobs and allows us to remove the hack of overriding the perform_in function in several of our workers
